### PR TITLE
change code wrappering on header.html

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -62,9 +62,7 @@
         <path d="M11.5 3a17 17 0 0 0 0 18" />
         <path d="M12.5 3a17 17 0 0 1 0 18" />
       </svg>
-      <a href="/{{ .Lang }}" lang="{{ .Lang }}">{{ default .Lang
-        .LanguageName
-        }}</a>
+      <a href="/{{ .Lang }}" lang="{{ .Lang }}">{{ default .Lang .LanguageName }}</a>
       {{ end }}
       {{ end }}
     </li>


### PR DESCRIPTION
I was getting this error:

```
hugo serve
Error: add site dependencies: load resources: loading templates: "my/file/system/test-blist/themes/blist/layouts/partials/header.html:65:1": parse failed: template: partials/header.html:65: unclosed action
```
So, I changed the header code wrapping for line 65. I'm not sure what was wrong with the code - there was no apparent "unclosed action". No actual code changed aside from removing two carriage returns, but after that, my site could build. I was following the instructions from this closed issue: #https://github.com/apvarun/blist-hugo-theme/issues/4. 



